### PR TITLE
Fix auth cookie security and add Vercel blob storage domain

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -73,9 +73,13 @@ export async function POST(request: NextRequest) {
       name: user.name,
     });
 
+    // Use secure flag only when the app is actually served over HTTPS.
+    // NODE_ENV=production alone is not enough — local/intranet deploys may
+    // run on plain HTTP even in production mode.
+    const isHttps = (process.env.NEXTAUTH_URL ?? '').startsWith('https://');
     cookies().set('auth-token', token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: isHttps,
       sameSite: 'strict',
       path: '/',
       maxAge: 60 * 60 * 24, // 24 hours

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,7 +24,7 @@ const securityHeaders = [
       "script-src 'self' 'unsafe-inline'",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' https://fonts.gstatic.com",
-      "img-src 'self' data: blob: https://blob.v0.dev",
+      "img-src 'self' data: blob: https://blob.v0.dev https://hebbkx1anhila5yf.public.blob.vercel-storage.com",
       "connect-src 'self'",
       "frame-ancestors 'none'",
       "form-action 'self'",
@@ -37,7 +37,7 @@ const securityHeaders = [
 const nextConfig = {
   output: 'standalone',
   images: {
-    domains: ['blob.v0.dev'],
+    domains: ['blob.v0.dev', 'hebbkx1anhila5yf.public.blob.vercel-storage.com'],
     unoptimized: true,
   },
   compress: true,


### PR DESCRIPTION
## Summary
This PR addresses two security and configuration issues: fixing the auth cookie's secure flag logic to properly detect HTTPS connections, and adding support for Vercel's blob storage service.

## Key Changes
- **Auth cookie security**: Changed the `secure` flag from checking `NODE_ENV === 'production'` to actually detecting HTTPS by inspecting the `NEXTAUTH_URL` environment variable. This ensures cookies are only marked secure when the app is genuinely served over HTTPS, preventing issues with local/intranet deployments that may run on plain HTTP even in production mode.

- **Image domain configuration**: Added `hebbkx1anhila5yf.public.blob.vercel-storage.com` to both the Next.js image domains whitelist and the Content Security Policy `img-src` directive to enable loading images from Vercel's blob storage service.

## Implementation Details
- The HTTPS detection uses a simple string check: `(process.env.NEXTAUTH_URL ?? '').startsWith('https://')`
- This approach is more reliable than relying solely on `NODE_ENV` since production deployments can run on various protocols depending on infrastructure setup

https://claude.ai/code/session_012ykSwV7TPHXoqzkz2Bg38G